### PR TITLE
Add automatic fixes and support record fields in all locations

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "elm/core": "1.0.2 <= v < 2.0.0",
         "jfmengels/elm-review": "2.4.2 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.2.3 <= v < 8.0.0"
+        "stil4m/elm-syntax": "7.2.6 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,0 +1,47 @@
+module Util exposing (declarationToFix, expressionToFix, patternToFix, typeAnnotationToFix)
+
+import Elm.Syntax.Declaration exposing (Declaration)
+import Elm.Syntax.Expression exposing (Expression)
+import Elm.Syntax.Node
+import Elm.Syntax.Pattern exposing (Pattern)
+import Elm.Syntax.Range exposing (Range)
+import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
+import Elm.Writer
+
+
+expressionToFix : Range -> Expression -> String
+expressionToFix range e =
+    Elm.Syntax.Node.Node range e
+        |> Elm.Writer.writeExpression
+        |> Elm.Writer.write
+        |> reindent range.start.column
+
+
+declarationToFix : Range -> Declaration -> String
+declarationToFix range d =
+    Elm.Syntax.Node.Node range d
+        |> Elm.Writer.writeDeclaration
+        |> Elm.Writer.write
+        |> reindent range.start.column
+
+
+patternToFix : Range -> Pattern -> String
+patternToFix range p =
+    Elm.Syntax.Node.Node range p
+        |> Elm.Writer.writePattern
+        |> Elm.Writer.write
+        |> reindent range.start.column
+
+
+typeAnnotationToFix : Range -> TypeAnnotation -> String
+typeAnnotationToFix range a =
+    Elm.Syntax.Node.Node range a
+        |> Elm.Writer.writeTypeAnnotation
+        |> Elm.Writer.write
+        |> reindent range.start.column
+
+
+reindent : Int -> String -> String
+reindent amount =
+    String.lines
+        >> String.join ("\n" ++ String.repeat (amount - 1) " ")

--- a/tests/RulesTest.elm
+++ b/tests/RulesTest.elm
@@ -1,5 +1,8 @@
 module RulesTest exposing (all)
 
+-- ! NOTE: Do not strip trailing whitespace in multi-line strings, or tests
+-- ! will fail; your IDE may do this automatically.
+
 import NoUnsortedConstructors
 import NoUnsortedRecordFields
 import Review.Test
@@ -28,31 +31,157 @@ all : Test
 all =
     describe "elm-review-sorted"
         [ describe "NoUnsortedRecordFields"
-            [ test "should report an error when record fields are unsorted" <|
+            [ test "unsorted declaration" <|
                 \() ->
                     """module A exposing (..)
+
 type alias Record = { b : Int, a : Int }
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{ b : Int, a : Int }"
+                                |> Review.Test.whenFixed
+                                    """module A exposing (..)
+
+type alias Record = {a : Int, b : Int}
+"""
+                            ]
+            , test "no error for single fields" <|
+                \() ->
+                    """module A exposing (..)
 
 type alias RecordTwo = { c : Bool }
-
-type WrappedRecord = Record { blue : String, black : { one : Bool, two : Bool, three : Bool } }
 
 getC : RecordTwo -> Bool
 getC {c} = c
 
-getB : { t | b : Int, a : Int }
-getB {b, a} = b
-
 makeRecordTwo : Bool -> RecordTwo
 makeRecordTwo c = {c = c}
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectNoErrors
+            , test "no error for sorted" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+type WrappedRecord = Record { black : { one : Bool, two : Bool, three : Bool }, blue : String }
+
+getB : { t | a : Int, b : Int }
+getB {a, b} = b
+
+lambdaFunction : Record -> Int
+lambdaFunction = \\{a, b} -> b
+
+letDestructuring : Record -> Int
+letDestructuring r =
+    let {a, b} = r
+    in b
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f : { t | a : Int, b : Int } -> Int
+        f {a, b} = b
+    in
+    f r
+
+casePatternMatch : Record -> Int
+casePatternMatch r =
+    case r of
+        {a, b} -> b
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectNoErrors
+            , test "nested records" <|
+                \() ->
+                    """module A exposing (..)
+
+type WrappedRecord = Record { blue : String, black : { one : Bool, two : Bool, three : Bool } }
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{ blue : String, black : { one : Bool, two : Bool, three : Bool } }"
+                                |> Review.Test.whenFixed
+                                    """module A exposing (..)
+
+type WrappedRecord = Record {black : {one : Bool, two : Bool, three : Bool}, blue : String}
+"""
+                            ]
+            , test "generic record and argument destructure" <|
+                \() ->
+                    """module A exposing (..)
+
+getB : { t | b : Int, a : Int }
+getB {b, a} = b
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{ t | b : Int, a : Int }"
+                                |> Review.Test.whenFixed
+                                    """module A exposing (..)
+
+getB : { t | a : Int, b : Int }
+getB {b, a} = b
+"""
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.whenFixed
+                                    """module A exposing (..)
+
+getB : { t | b : Int, a : Int }
+getB {a, b} = b
+"""
+                            ]
+            , test "lamda function" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
 
 lambdaFunction : Record -> Int
 lambdaFunction = \\{b, a} -> b
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+lambdaFunction : Record -> Int
+lambdaFunction = \\{a, b} -> b
+"""
+                            ]
+            , test "let destructuring" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
 
 letDestructuring : Record -> Int
 letDestructuring r =
     let {b, a} = r
     in b
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+letDestructuring : Record -> Int
+letDestructuring r =
+    let {a, b} = r
+    in b
+"""
+                            ]
+            , test "function signature and argument destructuring in let binding" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
 
 letFuncSigAndDestructuring : Record -> Int
 letFuncSigAndDestructuring r =
@@ -61,6 +190,41 @@ letFuncSigAndDestructuring r =
         f {b, a} = b
     in
     f r
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError "{ t | b : Int, a : Int }"
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f : { t | a : Int, b : Int } -> Int
+        f {b, a} = b
+    in
+    f r
+"""
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f : { t | b : Int, a : Int } -> Int
+        f {a, b} = b
+    in
+    f r
+"""
+                            ]
+            , test "case pattern match" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
 
 casePatternMatch : Record -> Int
 casePatternMatch r =
@@ -69,29 +233,98 @@ casePatternMatch r =
 """
                         |> Review.Test.run NoUnsortedRecordFields.rule
                         |> Review.Test.expectErrors
-                            [ unsortedRecordFieldsError "{ b : Int, a : Int }"
-                            , unsortedRecordFieldsError "{ blue : String, black : { one : Bool, two : Bool, three : Bool } }"
-                            , unsortedRecordFieldsError " b : Int, a : Int "
-                                |> Review.Test.atExactly { start = { row = 11, column = 13 }, end = { row = 11, column = 31 } }
-                            , unsortedRecordFieldsError "{b, a}"
-                                |> Review.Test.atExactly { start = { row = 12, column = 6 }, end = { row = 12, column = 12 } }
-                            , unsortedRecordFieldsError "{b, a}"
-                                |> Review.Test.atExactly { start = { row = 18, column = 19 }, end = { row = 18, column = 25 } }
-                            , unsortedRecordFieldsError "{b, a}"
-                                |> Review.Test.atExactly { start = { row = 22, column = 9 }, end = { row = 22, column = 15 } }
-                            , unsortedRecordFieldsError " b : Int, a : Int "
-                                |> Review.Test.atExactly { start = { row = 28, column = 18 }, end = { row = 28, column = 36 } }
-                            , unsortedRecordFieldsError "{b, a}"
-                                |> Review.Test.atExactly { start = { row = 29, column = 11 }, end = { row = 29, column = 17 } }
-                            , unsortedRecordFieldsError "{b, a}"
-                                |> Review.Test.atExactly { start = { row = 36, column = 9 }, end = { row = 36, column = 15 } }
+                            [ unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+casePatternMatch : Record -> Int
+casePatternMatch r =
+    case r of
+        {a, b} -> b
+"""
+                            ]
+            , test "multiline signature in let" <|
+                \() ->
+                    """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f :
+            { t
+                | b : Int
+                , a : Int
+            }
+            -> Int
+        f { a, b } =
+            b
+    in
+    f r
+"""
+                        |> Review.Test.run NoUnsortedRecordFields.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedRecordFieldsError """{ t
+                | b : Int
+                , a : Int
+            }"""
+                                |> Review.Test.whenFixed """module A exposing (..)
+
+type alias Record = { a : Int, b : Int }
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f :
+            { t | a : Int, b : Int }
+            -> Int
+        f { a, b } =
+            b
+    in
+    f r
+"""
                             ]
             ]
         , describe "NoUnsortedConstructors"
-            [ test "should report an error when constructors are unsorted" <|
+            [ test "unsorted declaration" <|
                 \() ->
                     """module B exposing (..)
 type Alternative = C | B | A
+"""
+                        |> Review.Test.run NoUnsortedConstructors.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedConstructorsError "type Alternative = C | B | A" |> Review.Test.whenFixed """module B exposing (..)
+type Alternative 
+    =A |B |C 
+"""
+                            ]
+            , test "unsorted declaration multiline" <|
+                \() ->
+                    """module B exposing (..)
+
+type Multiline
+    = Foo
+    | Baz
+    | Bar
+"""
+                        |> Review.Test.run NoUnsortedConstructors.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedConstructorsError """type Multiline
+    = Foo
+    | Baz
+    | Bar""" |> Review.Test.whenFixed """module B exposing (..)
+
+type Multiline 
+    =Bar 
+    |Baz 
+    |Foo 
+"""
+                            ]
+            , test "unsorted case" <|
+                \() ->
+                    """module B exposing (..)
 
 toString : Maybe Alternative -> String
 toString alternative = case alternative of
@@ -101,12 +334,55 @@ toString alternative = case alternative of
     Just C -> "C" """
                         |> Review.Test.run NoUnsortedConstructors.rule
                         |> Review.Test.expectErrors
-                            [ unsortedConstructorsError "type Alternative = C | B | A"
-                            , unsortedConstructorsError """case alternative of
+                            [ unsortedConstructorsError """case alternative of
     Nothing -> ""
     Just B -> "B"
     Just A -> "A"
+    Just C -> "C" """ |> Review.Test.whenFixed """module B exposing (..)
+
+toString : Maybe Alternative -> String
+toString alternative = 
+                       case alternative of
+                         Just A  ->
+                           "A"
+                         Just B  ->
+                           "B"
+                         Just C  ->
+                           "C"
+                         Nothing  ->
+                           ""
+                        """
+                            ]
+            , test "should report an error when constructors are unsorted in a case" <|
+                \() ->
+                    """module B exposing (..)
+
+toString : Maybe Alternative -> String
+toString alternative = case alternative of
+    Nothing -> List.map .x <| y
+    Just B -> "B"
+    Just A -> "A"
     Just C -> "C" """
+                        |> Review.Test.run NoUnsortedConstructors.rule
+                        |> Review.Test.expectErrors
+                            [ unsortedConstructorsError """case alternative of
+    Nothing -> List.map .x <| y
+    Just B -> "B"
+    Just A -> "A"
+    Just C -> "C" """ |> Review.Test.whenFixed """module B exposing (..)
+
+toString : Maybe Alternative -> String
+toString alternative = 
+                       case alternative of
+                         Just A  ->
+                           "A"
+                         Just B  ->
+                           "B"
+                         Just C  ->
+                           "C"
+                         Nothing  ->
+                           List.map .x <| y
+                        """
                             ]
             ]
         ]

--- a/tests/RulesTest.elm
+++ b/tests/RulesTest.elm
@@ -45,6 +45,27 @@ getB {b, a} = b
 
 makeRecordTwo : Bool -> RecordTwo
 makeRecordTwo c = {c = c}
+
+lambdaFunction : Record -> Int
+lambdaFunction = \\{b, a} -> b
+
+letDestructuring : Record -> Int
+letDestructuring r =
+    let {b, a} = r
+    in b
+
+letFuncSigAndDestructuring : Record -> Int
+letFuncSigAndDestructuring r =
+    let
+        f : { t | b : Int, a : Int } -> Int
+        f {b, a} = b
+    in
+    f r
+
+casePatternMatch : Record -> Int
+casePatternMatch r =
+    case r of
+        {b, a} -> b
 """
                         |> Review.Test.run NoUnsortedRecordFields.rule
                         |> Review.Test.expectErrors
@@ -53,6 +74,17 @@ makeRecordTwo c = {c = c}
                             , unsortedRecordFieldsError " b : Int, a : Int "
                                 |> Review.Test.atExactly { start = { row = 11, column = 13 }, end = { row = 11, column = 31 } }
                             , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.atExactly { start = { row = 12, column = 6 }, end = { row = 12, column = 12 } }
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.atExactly { start = { row = 18, column = 19 }, end = { row = 18, column = 25 } }
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.atExactly { start = { row = 22, column = 9 }, end = { row = 22, column = 15 } }
+                            , unsortedRecordFieldsError " b : Int, a : Int "
+                                |> Review.Test.atExactly { start = { row = 28, column = 18 }, end = { row = 28, column = 36 } }
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.atExactly { start = { row = 29, column = 11 }, end = { row = 29, column = 17 } }
+                            , unsortedRecordFieldsError "{b, a}"
+                                |> Review.Test.atExactly { start = { row = 36, column = 9 }, end = { row = 36, column = 15 } }
                             ]
             ]
         , describe "NoUnsortedConstructors"


### PR DESCRIPTION
Added checking record field order in the following places:

* Lambda args, e.g. `\{b, a} -> b`
* `let` destructuring, e.g. `let {b, a} = r in ...`
* `let` function sigs, e.g. `let f : { t | b : Int, a : Int } -> Int`
* `let` function args, e.g. `let f {b, a} = b in ...`
* `case` pattern matching, e.g. `case r of {b, a} -> b`

Added a single destructuring example to the documentation:
```
sumFoo : Foo -> Int
sumFoo { b, a } =
    a + b
```
since this behavior was already checked for.

Broke out `functionSorted`, `patternSorted`, and `typeAnnotationSorted` into TLDs, since they are now used in multiple places.

If this is excessive, I understand, but it extends the behavior already present for TLDs to everywhere the same patterns can occur.  If it's beyond the intended scope of the rule, we could potentially add a rule option to enable this "deep" checking?