### PR TITLE
Use stable sort and don't compare code ranges

### DIFF
--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,4 +1,4 @@
-module Util exposing (declarationToFix, expressionToFix, patternToFix, typeAnnotationToFix)
+module Util exposing (declarationToFix, expressionToFix, patternToFix, stableSort, typeAnnotationToFix)
 
 import Elm.Syntax.Declaration exposing (Declaration)
 import Elm.Syntax.Expression exposing (Expression)
@@ -7,6 +7,33 @@ import Elm.Syntax.Pattern exposing (Pattern)
 import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation)
 import Elm.Writer
+
+
+{-| Sort a list stably and return the sorted version or `Nothing` if it is
+already sorted. This does not require checking equality of `a`.
+-}
+stableSort : (a -> a -> Order) -> List a -> Maybe (List a)
+stableSort comp xs =
+    let
+        withIndex =
+            List.indexedMap Tuple.pair xs
+
+        stableCompare ( i1, x1 ) ( i2, x2 ) =
+            case comp x1 x2 of
+                EQ ->
+                    compare i1 i2
+
+                ltOrGt ->
+                    ltOrGt
+
+        sorted =
+            List.sortWith stableCompare withIndex
+    in
+    if List.map Tuple.first sorted == List.map Tuple.first withIndex then
+        Nothing
+
+    else
+        Just (List.map Tuple.second sorted)
 
 
 expressionToFix : Range -> Expression -> String


### PR DESCRIPTION
The use of `List.sortWith` is problematic, as it is not guaranteed to be stable, which could lead to rare scenarios where `case` expressions that could not be sorted (i.e. patterns that were said to be `EQ`) would be flagged as unsorted.  (See, for example, [this CI failure](https://github.com/SiriusStarr/elm-spaced-repetition/runs/3185474448).) 

This PR eliminates the problem by sorting by original index in such ambiguous cases.  This also allows us to avoid using equality on `Elm.Syntax.Node`s, which is potentially expensive, by simply comparing the index ordering.